### PR TITLE
Update VL53L1X.cpp (bugfix)

### DIFF
--- a/VL53L1X.cpp
+++ b/VL53L1X.cpp
@@ -681,7 +681,7 @@ void VL53L1X::getRangingData()
       break;
 
     case 6: // SIGMATHRESHOLDCHECK
-      ranging_data.range_status = SignalFail;
+      ranging_data.range_status = SigmaFail;
       break;
 
     case 7: // PHASECONSISTENCY


### PR DESCRIPTION
Correct typo from SignalFail to SigmaFail